### PR TITLE
Fix PeftMixedModel docstring #1824

### DIFF
--- a/src/peft/mixed_model.py
+++ b/src/peft/mixed_model.py
@@ -97,7 +97,6 @@ class PeftMixedModel(PushToHubMixin, torch.nn.Module):
     Example:
 
     ```py
-    >>> from peft import get_peft_model
 
     >>> base_model = ...  # load the base model, e.g. from transformers
     >>> peft_model = PeftMixedModel.from_pretrained(base_model, path_to_adapter1, "adapter1").eval()


### PR DESCRIPTION
What does this PR Do?

This PR removes the redundant import in the PeftMixedModel example and was confusing as raised here: #1824
Import was not required for the example, so removed it.